### PR TITLE
High Contrast compatability

### DIFF
--- a/SekiroFpsUnlockAndMore/MainWindow.xaml
+++ b/SekiroFpsUnlockAndMore/MainWindow.xaml
@@ -7,7 +7,7 @@
         mc:Ignorable="d"
         Title="Sekiro FPS Unlocker and more v1.2.5" Width="Auto" Height="Auto" SizeToContent="WidthAndHeight" ResizeMode="CanMinimize" Loaded="Window_Loaded" Closing="Window_Closing">
 
-    <Grid Background="#FFF9F9F9">
+    <Grid>
         <DockPanel>
             <StackPanel DockPanel.Dock="Top" Margin="10,10,10,0" Width="300" Height="Auto">
                 <DockPanel LastChildFill="False">
@@ -33,7 +33,7 @@
                 </StackPanel>
                 <CheckBox x:Name="cbLogStats" Margin="0,5,0,0" Height="25" FontSize="14 px" VerticalContentAlignment="Center" Content="Log stats (Deaths, Kills) to file for OBS" ToolTip="Check the guide on how to display these on stream with OBS" Checked="CbStatChanged" Unchecked="CbStatChanged" TabIndex="10" />
                 <Expander x:Name="exGameMods" Margin="-3,5,0,0" Height="Auto" FontSize="14 px" Header="Modifications" IsExpanded="True" TabIndex="11">
-                    <Grid Margin="3,1,0,0" Background="#FFF9F9F9">
+                    <Grid Margin="3,1,0,0">
                         <StackPanel Width="Auto" Height="Auto">
                             <CheckBox x:Name="cbCamAdjust" Margin="0,5,0,0" Height="25" FontSize="14 px" VerticalContentAlignment="Center" Content="Disable camera auto rotate on movement" ToolTip="Disables the annoying automatic camera adjustment on movement. Intended for mouse users" Checked="CbCamAdjust_Check_Handler" Unchecked="CbCamAdjust_Check_Handler" TabIndex="12" />
                             <CheckBox x:Name="cbCamReset" Margin="0,3,0,0" Height="25" FontSize="14 px" VerticalContentAlignment="Center" Content="Disable camera reset on lock-on" ToolTip="Disables the annoying camera centering on lock-on when there is no target" Checked="CbCamReset_Check_Handler" Unchecked="CbCamReset_Check_Handler" TabIndex="13" />


### PR DESCRIPTION
# Problem
![OG](https://user-images.githubusercontent.com/44919476/71573575-b438b680-2b38-11ea-892c-4af630d98580.png)

This is what the app looks like on Windows with HIgh Contrast enabled (I cropped the image). You've decided the background should be white. The OS decided the text should be light gray. The result is that I can't read anything. 

# Solution
![Fixed](https://user-images.githubusercontent.com/44919476/71573621-f3ff9e00-2b38-11ea-881e-d1732e0e8f45.png)
 
Let the OS control all of the colors. This works correctly without High Contrast as well

![FixedNonHC](https://user-images.githubusercontent.com/44919476/71573642-1396c680-2b39-11ea-93be-dfbab69c20b4.png)

